### PR TITLE
[CUBRIDQA-1528] probe check.yml job-level permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,10 +21,15 @@ on:
       - develop
       - 'release/11.**'
       - 'feature/**'
+
+permissions: {} # Least privilege — jobs opt-in below
+
 jobs:
   license:
     name: license
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
     steps:
       - uses: actions/checkout@v5
       - id: files
@@ -79,12 +84,18 @@ jobs:
   pr-style:
     name: pr-style
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout
+      pull-requests: read # check-pr-title (pulls API)
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/check-pr-title
   code-style:
     name: code-style
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
+      pull-requests: write # reviewdog/action-suggester posts review comments
     env:
       working-directory: .github/workflows
     steps:
@@ -131,6 +142,9 @@ jobs:
   cppcheck:
     name: cppcheck
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
+      pull-requests: write # unsplash/comment-on-pr posts the summary
     steps:
       - name: Install packages
         run: |
@@ -216,6 +230,8 @@ jobs:
   memory-monitor-check:
     name: memory-monitor-check
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
     steps:
       - uses: actions/checkout@v5
       - id: files

--- a/src/base/probe_1528.c
+++ b/src/base/probe_1528.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/* Throwaway probe for CUBRIDQA-1528. Never merged anywhere.
+ * Deliberately breaks two checks at once:
+ *   code-style -> GNU indent rewrites this brace/spacing style, git diff is non-empty
+ *   cppcheck   -> arrayIndexOutOfBounds is reported at " error: " level
+ */
+int probe_1528_oob(void){
+int a[2];
+a[5]=1;
+return a[0];
+}


### PR DESCRIPTION
Throwaway probe. Verifies that the explicit job-level `permissions:` in check.yml let both PR-writing steps still work while the repository-wide Workflow permissions setting is read-only (this fork is already set to `read`).

Expected: `code-style` and `cppcheck` fail on `src/base/probe_1528.c`, and their `if: failure()` steps (reviewdog/action-suggester, unsplash/comment-on-pr) succeed in writing to this PR.

Not for merge. Cleanup is tracked under CUBRIDQA-1529.