### PR TITLE
throwaway: CUBRIDQA-1526 concurrency group test

### DIFF
--- a/CONCURRENCY-TEST-1526
+++ b/CONCURRENCY-TEST-1526
@@ -1,0 +1,2 @@
+Throwaway branch for the CUBRIDQA-1526 concurrency-group test.
+Delete with the pull request. Not referenced by anything.


### PR DESCRIPTION
버릴 PR 이다. `gha-ci.yml` 의 새 `concurrency.group` 이 요청 종류를 실제로 가르는지 코멘트로 시험한다.

base 를 fork 기본 브랜치로 잡았다. 그래서 `tc-branch-sync` · `tc-branch-finalize` · `tc-merge-gate` · `github-checks` 가 전부 `branches` 필터에 안 걸리고, 공유 저장소(`CUBRID/cubrid-testcases{,-private-ex}`)에 아무것도 쓰지 않는다. `Comment trigger` 는 브랜치 필터가 없어 잠시 껐다.

시험 순서다.

| # | 코멘트 | 기대 |
|---|---|---|
| 1 | `/run shell` | run A 시작. group `gha-ci-pr-<N>-run` |
| 2 | `LGTM` | **run A 가 살아 있어야 한다.** 별 run 이 `gha-ci-<run_id>` 로 떠서 skip |
| 3 | `/run rerun 999` | **run A 가 살아 있어야 한다.** group `gha-ci-pr-<N>-rerun-<코멘트id>` |
| 4 | `/run shell` | **run A 가 취소되고** run B 가 시작 |

옛 키(`gha-ci-<PR번호>`)로는 2번과 3번이 run A 를 죽인다. 그것이 이 변경의 이유다.

끝나면 run 을 취소하고 이 PR 을 닫고 브랜치를 지우고 `Comment trigger` 를 되살린다.
